### PR TITLE
Add ambient crystal section and placeholder images

### DIFF
--- a/src/assets/images/ambiente_exoterico.svg
+++ b/src/assets/images/ambiente_exoterico.svg
@@ -1,0 +1,7 @@
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#f2e8d8"/>
+  <circle cx="200" cy="80" r="40" fill="#ffc107"/>
+  <polygon points="120,250 150,150 180,250" fill="#b0e0e6"/>
+  <polygon points="220,250 250,150 280,250" fill="#b0e0e6"/>
+  <text x="200" y="280" font-size="20" text-anchor="middle" fill="#333">Ambiente Exotérico</text>
+</svg>

--- a/src/assets/images/ambiente_paisagismo.svg
+++ b/src/assets/images/ambiente_paisagismo.svg
@@ -1,0 +1,8 @@
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#d0f0c0"/>
+  <rect x="0" y="220" width="400" height="80" fill="#8fbc8f"/>
+  <polygon points="60,220 90,130 120,220" fill="#b0e0e6"/>
+  <polygon points="180,220 210,130 240,220" fill="#b0e0e6"/>
+  <polygon points="300,220 330,130 360,220" fill="#b0e0e6"/>
+  <text x="200" y="280" font-size="20" text-anchor="middle" fill="#333">Paisagismo com Cristais</text>
+</svg>

--- a/src/components/AmbientesCristais/AmbientesCristais.jsx
+++ b/src/components/AmbientesCristais/AmbientesCristais.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components';
+import Container from '../UI/Container';
+import ambienteExoterico from '../../assets/images/ambiente_exoterico.svg';
+import ambientePaisagismo from '../../assets/images/ambiente_paisagismo.svg';
+
+const Section = styled.section`
+  padding: 4rem 0;
+  background-color: #f8f9fa;
+`;
+
+const Title = styled.h2`
+  font-size: 2.5rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  color: #333;
+`;
+
+const EnvironmentsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+`;
+
+const EnvCard = styled.div`
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  flex: 1;
+  min-width: 280px;
+  max-width: 450px;
+`;
+
+const EnvImage = styled.img`
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+`;
+
+const Description = styled.p`
+  font-size: 1.1rem;
+  line-height: 1.6;
+  text-align: justify;
+`;
+
+const BenefitsList = styled.ul`
+  margin-top: 2rem;
+  list-style: disc inside;
+`;
+
+const BenefitItem = styled.li`
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+  color: #333;
+  text-align: justify;
+`;
+
+const AmbientesCristais = () => (
+  <Section id="ambientes">
+    <Container>
+      <Title>Ambientes com Cristais</Title>
+      <EnvironmentsWrapper>
+        <EnvCard>
+          <EnvImage src={ambienteExoterico} alt="Ambiente exot\u00e9rico" />
+          <Description>
+            Espa\u00e7os exot\u00e9ricos utilizam cristais para potencializar pr\u00e1ticas espirituais, favorecendo a medita\u00e7\u00e3o e a purifica\u00e7\u00e3o de energias.
+          </Description>
+        </EnvCard>
+        <EnvCard>
+          <EnvImage src={ambientePaisagismo} alt="Paisagismo com cristais" />
+          <Description>
+            No paisagismo, os cristais embelezam jardins e canteiros, trazendo harmonia e conex\u00e3o com a natureza ao ambiente.
+          </Description>
+        </EnvCard>
+      </EnvironmentsWrapper>
+      <BenefitsList>
+        <BenefitItem>Purifica e protege a energia do local.</BenefitItem>
+        <BenefitItem>Auxilia na medita\u00e7\u00e3o e na eleva\u00e7\u00e3o espiritual.</BenefitItem>
+        <BenefitItem>Equilibra os chakras e fortalece a intui\u00e7\u00e3o.</BenefitItem>
+        <BenefitItem>Intensifica a sensa\u00e7\u00e3o de bem-estar em ambientes internos e externos.</BenefitItem>
+      </BenefitsList>
+    </Container>
+  </Section>
+);
+
+export default AmbientesCristais;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import Inovacao from '../components/Inovacao/Inovacao';
 import ConstrucaoCivil from '../components/ConstrucaoCivil/ConstrucaoCivil';
 import AreiaFiltrante from '../components/AreiaFiltrante/AreiaFiltrante';
 import Cristais from '../components/Cristais/Cristais';
+import AmbientesCristais from '../components/AmbientesCristais/AmbientesCristais';
 import PorqueEscolher from '../components/PorqueEscolher/PorqueEscolher';
 import Sobre from '../components/Sobre/Sobre';
 import Historia from '../components/Historia/Historia';
@@ -28,6 +29,7 @@ function Home() {
       <ConstrucaoCivil />
       <AreiaFiltrante />
       <Cristais />
+      <AmbientesCristais />
       <PorqueEscolher />
       <Sobre />
       <Historia />


### PR DESCRIPTION
## Summary
- add new images of crystal environments
- create `AmbientesCristais` component describing exoteric uses
- display `AmbientesCristais` on the home page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849997b2d0c832a8ddf11c1c7c461aa